### PR TITLE
Update OpenHands ports: GUI on 17243, API on 17244

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -42,7 +42,7 @@ status:
 	@docker ps --filter "name=openhands-gui"
 	@echo ""
 	@echo "Prufe OpenHands API-Status..."
-	@curl -s http://localhost:17243/api/status || echo "OpenHands API nicht erreichbar"
+	@curl -s http://localhost:17244/api/status || echo "OpenHands API nicht erreichbar"
 
 # Integrationstests ausfuhren
 test:

--- a/src/README.md
+++ b/src/README.md
@@ -4,8 +4,8 @@ Diese Integration verbindet OpenHands mit GPT-CLI und dem Dev-Server-Workflow, u
 
 ## Funktionen
 
-- OpenHands im GUI-Modus (Port 3000) in einem Docker-Container ausführen
-- OpenHands über die API (Port 17243) steuern
+- OpenHands im GUI-Modus (Port 17243) in einem Docker-Container ausführen
+- OpenHands über die API (Port 17244) steuern
 - GPT-CLI verwenden, um Tests auf Repositories auszuführen
 - Automatisch GitHub-Issues für Testfehler erstellen
 - OpenHands auslösen, um Issues zu beheben
@@ -37,7 +37,7 @@ Die Integration besteht aus folgenden Komponenten:
    ```
 
 2. Konfiguriere OpenHands:
-   - Greife auf die OpenHands GUI unter http://localhost:3000 zu
+   - Greife auf die OpenHands GUI unter http://localhost:17243 zu
    - Gehe zu Einstellungen → API-Schlüssel und füge deine API-Schlüssel hinzu
    - Gehe zu Einstellungen → Git-Einstellungen und füge deinen GitHub-Token hinzu
 

--- a/src/config/openhands.toml
+++ b/src/config/openhands.toml
@@ -1,6 +1,6 @@
 [api]
 host = "0.0.0.0"
-port = 17243
+port = 17244
 
 [gui]
 enabled = true

--- a/src/docker/docker-compose.yml
+++ b/src/docker/docker-compose.yml
@@ -5,8 +5,8 @@ services:
     image: docker.all-hands.dev/all-hands-ai/openhands:latest
     container_name: openhands-gui
     ports:
-      - "3000:3000"  # GUI mode on port 3000
-      - "17243:17243"  # API port
+      - "17243:3000"  # GUI mode on port 17243 (mapped from internal 3000)
+      - "17244:17243"  # API port on 17244 (mapped from internal 17243)
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - ../workspace:/app/workspace
@@ -14,7 +14,7 @@ services:
       - ../config/github_token.txt:/root/.openhands/github_token.txt
     environment:
       - OPENHANDS_GUI_MODE=true
-      - OPENHANDS_API_PORT=17243
+      - OPENHANDS_API_PORT=17244
       - OPENHANDS_WORKSPACE_PATH=/app/workspace
     networks:
       - integration-network

--- a/src/run.sh
+++ b/src/run.sh
@@ -37,7 +37,7 @@ echo -e "${YELLOW}Warte, bis OpenHands bereit ist...${NC}"
 MAX_RETRIES=30
 RETRY_COUNT=0
 while [ $RETRY_COUNT -lt $MAX_RETRIES ]; do
-    if curl -s http://localhost:17243/api/status > /dev/null; then
+    if curl -s http://localhost:17244/api/status > /dev/null; then
         echo -e "${GREEN}OpenHands ist bereit!${NC}"
         break
     fi
@@ -58,8 +58,8 @@ make test
 # Gib Erfolgsmeldung aus
 echo -e "${GREEN}Integration lauft erfolgreich!${NC}"
 echo ""
-echo "OpenHands GUI: http://localhost:3000"
-echo "OpenHands API: http://localhost:17243"
+echo "OpenHands GUI: http://localhost:17243"
+echo "OpenHands API: http://localhost:17244"
 echo ""
 echo "Verfugbare Befehle:"
 echo "  gpt run-tests --repo-path /pfad/zum/repository"

--- a/src/scripts/dev_server_cli_wrapper.py
+++ b/src/scripts/dev_server_cli_wrapper.py
@@ -23,7 +23,7 @@ logger = logging.getLogger("dev-server-cli-wrapper")
 
 # Constants
 DEV_SERVER_DIR = os.path.expanduser("~/Dev-Server-Workflow")
-OPENHANDS_API_URL = "http://localhost:17243/api/tasks"
+OPENHANDS_API_URL = "http://localhost:17244/api/tasks"
 
 
 def parse_args():

--- a/src/scripts/dev_server_installer.py
+++ b/src/scripts/dev_server_installer.py
@@ -264,14 +264,14 @@ def integrate_with_openhands(install_dir):
     # Check if OpenHands is running
     try:
         import requests
-        response = requests.get("http://localhost:17243/api/status")
+        response = requests.get("http://localhost:17244/api/status")
         if response.status_code == 200:
             logger.info("OpenHands is running")
         else:
             logger.warning("OpenHands API returned non-200 status code")
     except Exception:
         logger.warning("OpenHands API not accessible")
-        logger.info("Make sure OpenHands is running on port 17243")
+        logger.info("Make sure OpenHands is running on port 17244")
     
     # Create integration directory in OpenHands workspace
     openhands_workspace = os.path.expanduser("~/openhands-workspace")

--- a/src/scripts/fix_issue.py
+++ b/src/scripts/fix_issue.py
@@ -14,7 +14,7 @@ import argparse
 from pathlib import Path
 
 # Constants
-OPENHANDS_API_URL = "http://localhost:17243/api/tasks"
+OPENHANDS_API_URL = "http://localhost:17244/api/tasks"
 
 
 def parse_args():

--- a/src/scripts/integrate_dev_server.py
+++ b/src/scripts/integrate_dev_server.py
@@ -24,7 +24,7 @@ logger = logging.getLogger("integrate-dev-server")
 # Constants
 DEV_SERVER_DIR = os.path.expanduser("~/Dev-Server-Workflow")
 OPENHANDS_WORKSPACE = os.path.expanduser("~/openhands-workspace")
-OPENHANDS_API_URL = "http://localhost:17243/api/tasks"
+OPENHANDS_API_URL = "http://localhost:17244/api/tasks"
 
 
 def parse_args():

--- a/src/scripts/openhands_api.py
+++ b/src/scripts/openhands_api.py
@@ -15,7 +15,7 @@ from typing import Dict, Any, Optional, List, Union
 class OpenHandsAPI:
     """Python wrapper for the OpenHands API."""
 
-    def __init__(self, base_url: str = "http://localhost:17243"):
+    def __init__(self, base_url: str = "http://localhost:17244"):
         """Initialize the OpenHands API wrapper.
 
         Args:

--- a/src/scripts/setup.sh
+++ b/src/scripts/setup.sh
@@ -122,7 +122,7 @@ cd ..
 echo -e "${GREEN}Setup erfolgreich abgeschlossen!${NC}"
 echo ""
 echo "Nächste Schritte:"
-echo "1. Greife auf die OpenHands GUI unter http://localhost:3000 zu"
+echo "1. Greife auf die OpenHands GUI unter http://localhost:17243 zu"
 echo "2. In der OpenHands GUI, konfiguriere API-Schlüssel (Einstellungen → API-Schlüssel)"
 echo "3. Führe Tests aus mit: gpt run-tests --repo-path /pfad/zum/repo"
 echo "4. Überprüfe PRs mit: gpt check-pr <PR_NUMMER> --repo-path /pfad/zum/repo"

--- a/src/scripts/test_and_report.py
+++ b/src/scripts/test_and_report.py
@@ -16,7 +16,7 @@ import argparse
 from pathlib import Path
 
 # Constants
-OPENHANDS_API_URL = "http://localhost:17243/api/tasks"
+OPENHANDS_API_URL = "http://localhost:17244/api/tasks"
 GITHUB_LABEL = "fix-me"
 
 

--- a/src/scripts/workflow_loop.py
+++ b/src/scripts/workflow_loop.py
@@ -31,7 +31,7 @@ logger = logging.getLogger("workflow-loop")
 
 # Constants
 DEV_SERVER_DIR = os.path.expanduser("~/Dev-Server-Workflow")
-OPENHANDS_API_URL = "http://localhost:17243/api/tasks"
+OPENHANDS_API_URL = "http://localhost:17244/api/tasks"
 CHECK_INTERVAL = 300  # 5 minutes
 MAX_RETRIES = 3
 

--- a/src/tests/test_integration.py
+++ b/src/tests/test_integration.py
@@ -86,7 +86,7 @@ class TestIntegration(unittest.TestCase):
     def test_openhands_api_accessible(self):
         """Test that OpenHands API is accessible."""
         try:
-            response = requests.get("http://localhost:17243/api/status")
+            response = requests.get("http://localhost:17244/api/status")
             self.assertEqual(response.status_code, 200)
             print("OpenHands API is accessible")
         except Exception as e:


### PR DESCRIPTION
# Port Update

This PR updates the OpenHands ports to use non-standard ports:

- GUI: http://localhost:17243 (mapped from internal port 3000)
- API: http://localhost:17244 (mapped from internal port 17243)

The changes include updates to:
- Docker configuration
- Environment variables
- OpenHands configuration
- README and documentation
- Scripts and API wrappers

This ensures that the OpenHands instance does not conflict with other services that might be using standard ports.